### PR TITLE
adds a break element at the end of a line

### DIFF
--- a/client/markdown.coffee
+++ b/client/markdown.coffee
@@ -6,6 +6,7 @@
 ###
 
 lineNumber = 0
+totalLines = 0
 
 headers = (line) ->
   line = line.replace /^#+(.*)$/, '<h3>$1</h3>'
@@ -21,7 +22,6 @@ emphasis = (line) ->
   line = line.replace /\_(\S)\_/g, '<i>$1</i>'
 
 lists = (line) ->
-  lineNumber++
   line = line.replace /^ *[*-] +(\[[ x]\])(.*)$/, (line, box, content) ->
     checked = if box == '[x]' then  ' checked' else ''
     "<li><input type=checkbox data-line=#{lineNumber}#{checked}>#{content}</li>"
@@ -37,9 +37,26 @@ code = (line) ->
   styles = 'background:rgba(0,0,0,0.04);padding:0.2em 0.4em;border-radius:3px'
   line.replace /`(\S.*?\S)`/g, "<code style=\"#{styles}\">$1</code>"
 
+breakLine = (line) ->
+  exp = /// (
+    [^>]+            # does not end with a tag
+    | <\/(i|b|code)> # or the tag is an inline tag (<i>, <b> or <code>)
+  ) $ ///
+
+  if lineNumber != totalLines - 1 and exp.test line
+    "#{line}<br>"
+  else
+    line
+
 expand = (text) ->
+  lines = text.split /\n/
+  totalLines = lines.length
   lineNumber = -1
-  (emphasis headers lists code escape line for line in text.split /\n/).join "\n"
+
+  output = for line in lines
+    lineNumber++
+    breakLine emphasis headers lists code escape line
+  output.join ""
 
 emit = ($item, item) ->
   $item.append """
@@ -65,7 +82,6 @@ bind = ($item, item) ->
       type: 'edit',
       id: item.id,
       item: item
-
 
 window.plugins.markdown = {emit, bind} if window?
 module.exports = {expand} if module?

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -21,7 +21,7 @@ describe 'markdown plugin', ->
 
     it 'can do ### on many lines', ->
       result = markdown.expand '###one\n###two'
-      expect(result).to.be '<h3>one</h3>\n<h3>two</h3>'
+      expect(result).to.be '<h3>one</h3><h3>two</h3>'
 
   describe 'emphasis', ->
 
@@ -136,3 +136,17 @@ describe 'markdown plugin', ->
     it 'ignores last back tick on odd number of back ticks', ->
       result = markdown.expand '`hello` `world'
       expect(result).to.be '<code style="background:rgba(0,0,0,0.04);padding:0.2em 0.4em;border-radius:3px">hello</code> `world'
+
+  describe 'breaks', ->
+
+    it 'adds a break element at the end of a line', ->
+      result = markdown.expand 'hello\nworld'
+      expect(result).to.be 'hello<br>world'
+
+    it 'adds a break element at the end of lines ending with inline elements', ->
+      result = markdown.expand '__Lorem__\n*ipsum*\ndolor\n`code`\nlast element'
+      expect(result).to.be '<b>Lorem</b><br><i>ipsum</i><br>dolor<br><code style="background:rgba(0,0,0,0.04);padding:0.2em 0.4em;border-radius:3px">code</code><br>last element'
+
+    it "doesn't add a break element after block elements", ->
+      result = markdown.expand '- [x] hello world\n###lorem ipsum'
+      expect(result).to.be '<li><input type=checkbox data-line=0 checked> hello world</li><h3>lorem ipsum</h3>'


### PR DESCRIPTION
This is the first attempt to address #3.

The idea is to add a `<br>` element at the end of each line that:
- Doesn't end with an element
- Or it ends with an inline element
