### PR TITLE
optionally source a graph from links

### DIFF
--- a/client/markdown.coffee
+++ b/client/markdown.coffee
@@ -51,6 +51,18 @@ emit = ($item, item) ->
       #{wiki.resolveLinks item.text, expand}
   """
 
+  if item.graph
+    $item.addClass 'graph-source'
+    $item.get(0).graphData = ->
+      graph = {}
+      title = $item.parents('.page').find('h1').text().trim()
+      graph[title] = links = []
+      for match in item.text.match(/\[\[(.+?)\]\]/g)
+        link = match.slice(2,-2)
+        links.push link
+        graph[link] = []
+      graph
+
 toggle = (item, taskNumber) ->
   n = 0
   item.text = item.text.replace /\[[ x]\]/g, (box, i, original) ->


### PR DESCRIPTION
This pull request adds graph-source ability to markdown paragraphs. This imitates some of the capabilities of the Graph plugin in a much more compact form. The graph-source mechanism is enabled by adding `"graph":true` to the item. 

![image](https://user-images.githubusercontent.com/12127/47947889-e02fbc00-dee2-11e8-9e08-fa8ac22be68f.png)

Here is an example of the translator that exploits this feature to create the above pages.
https://github.com/WardCunningham/GroupWorks/commits/master

See more about the GroupWorks Pattern Language:
https://groupworksdeck.org/